### PR TITLE
Remove unnecessary computations

### DIFF
--- a/bsa_respiration_analyze_one_run.m
+++ b/bsa_respiration_analyze_one_run.m
@@ -71,27 +71,7 @@ else
     capSignal = (-1)*capSignal;
 end
 
-% Step1: detrending
-capSignal = detrend(capSignal);
-
 capFiltered = smooth(capSignal)'; 
-
-% Step2: create a butterworth filter order selection (low pass filter)
-% Fn  = Fs/2;                                                 % Nyquist Frequency (Hz)
-% Wp  = 40/Fn;                                                % Passband Frequency (Normalised)
-% Ws  = 100/Fn;                                               % Stopband Frequency (Normalised)
-% Rp  = 1;                                                    % Passband Ripple (dB)
-% Rs  = 150;                                                  % Stopband Ripple (dB)
-% [n,Wn]  = buttord(Wp,Ws,Rp,Rs);                             % Filter Order
-% [z,p,k] = butter(n,Wn);
-% [sos,g] = zp2sos(z,p,k);
-% 
-% 
-% % Filter raw ECG using filtfilt from Matlab
-% capFiltered = filtfilt(sos, g, capSignal); 
-
-
-
 
 if 0 % Debug
     figure ('Name','Single-sided amplitude spectrum');
@@ -352,13 +332,12 @@ if TOPLOT
     plot(t,capFiltered,'b'); 
     plot(t(locs_min),capFiltered(locs_min),'bo','MarkerSize',6);
 
-    plot(t(locs_peak(idx_wo_outliers)),capFiltered(locs_peak(idx_wo_outliers)),'ko','MarkerSize',6);
-    plot(t(maybe_valid_pos_ecg_locs),capFiltered(maybe_valid_pos_ecg_locs),'kv','MarkerSize',6,'MarkerEdgeColor',[0.5 0.5 0.5]);
+    plot(t(locs_peak(idx_wo_outliers)),capSignal(locs_peak(idx_wo_outliers)),'ko','MarkerSize',6);
      % valid R peaks
-    plot(t(R_valid_locs),capFiltered(R_valid_locs),'mv','MarkerFaceColor',[1 1 1],'MarkerSize',6);
+    plot(t(R_valid_locs),capSignal(R_valid_locs),'mv','MarkerFaceColor',[1 1 1],'MarkerSize',6);
     %valid B2B intervals -> filled TRIANGLE
-    plot(t(B2B_valid_locs),capFiltered(B2B_valid_locs),'mv','MarkerFaceColor',[1.0000    0.6000    0.7843],'MarkerSize',6);
-    plot(t(locs_peak(idx_outliers)),capFiltered(locs_peak(idx_outliers)),'bx');
+    plot(t(B2B_valid_locs),capSignal(B2B_valid_locs),'mv','MarkerFaceColor',[1.0000    0.6000    0.7843],'MarkerSize',6);
+    plot(t(locs_peak(idx_outliers)),capSignal(locs_peak(idx_outliers)),'bx');
    
     %line for 
     plot([t(B2B_valid_locs(idx_valid_B2B_consec)) - B2B_valid(idx_valid_B2B_consec); t(B2B_valid_locs(idx_valid_B2B_consec))], ...

--- a/bsa_respiration_analyze_one_run.m
+++ b/bsa_respiration_analyze_one_run.m
@@ -62,10 +62,10 @@ run(settings_path)
 n_samples       = length(capSignal);
 t               = 0:1/Fs:1/Fs*(n_samples-1); % time axis  -> IMPORTANT: first sample is time 0! (not 1/Fs)
 
-% Step0: flip cap signal if it's positive, leave the same if below zero
-% This will keep the signal the same even after swapping electrodes - plan
-% to reprogram vice versa to put positive signal into the cap analysis
-if median(capSignal) < 0
+% Step 1: flip cap signal if it's negative, leave the same if it's above zero
+% This will keep the signal the same after swapping connectors between TDT
+% and capnographic monitor (done by Luba in June 2023)
+if median(capSignal) > 0
     % do nothing to the signal
 else
     capSignal = (-1)*capSignal;

--- a/bsa_respiration_analyze_one_run.m
+++ b/bsa_respiration_analyze_one_run.m
@@ -98,7 +98,10 @@ MinPeakProminence = median (capFiltered_rectified)* Set.cap.MinPeakProminenceCoe
 % 1) amplitude of the previous & next minimum
 % 2) Distance between two peaks
 % 3) Min Peak height
-[pks,locs_peak]=findpeaks(capFiltered,'threshold',eps,'MinPeakProminence',MinPeakProminence,'minpeakdistance',fix(Set.cap.min_P2P*Fs),'minpeakheight',Set.cap.eP_tc_minpeakheight_med_prop*median(capFiltered));
+[pks,locs_peak]=findpeaks(capFiltered, ...
+    'MinPeakProminence',MinPeakProminence, ...
+    'minpeakdistance',fix(Set.cap.min_P2P*Fs), ...
+    'minpeakheight',Set.cap.eP_tc_minpeakheight_med_prop*median(capFiltered));
 % find peaks which are next to each other without a minimum
 % locs = [locs_min, locs_peak]; 
 % locs = sort(locs); 


### PR DESCRIPTION
remove unnecessary computations from breathing analysis and checked peak detection in the flipped signal